### PR TITLE
Fix payment success notifications

### DIFF
--- a/bot/handlers/user/subscription.py
+++ b/bot/handlers/user/subscription.py
@@ -468,7 +468,10 @@ async def stars_successful_payment_handler(
     await session.commit()
 
     applied_referee_days = referral_bonus_info.get("referee_bonus_applied_days") if referral_bonus_info else None
-    final_end = referral_bonus_info.get("referee_new_end_date") if referral_bonus_info else activation_details["end_date"]
+    final_end = (referral_bonus_info.get("referee_new_end_date")
+                 if referral_bonus_info else None)
+    if not final_end:
+        final_end = activation_details["end_date"]
 
     current_lang = i18n_data.get("current_language", settings.DEFAULT_LANGUAGE)
     i18n: JsonI18n = i18n_data.get("i18n_instance")

--- a/bot/handlers/webhooks/tribute.py
+++ b/bot/handlers/webhooks/tribute.py
@@ -86,7 +86,10 @@ async def tribute_webhook_route(request: web.Request):
             _ = lambda k, **kw: i18n.gettext(lang, k, **kw)
 
             applied_ref_days = referral_bonus.get('referee_bonus_applied_days') if referral_bonus else None
-            final_end = referral_bonus.get('referee_new_end_date') if referral_bonus else activation_details.get('end_date')
+            final_end = (referral_bonus.get('referee_new_end_date')
+                         if referral_bonus else None)
+            if not final_end:
+                final_end = activation_details.get('end_date')
 
             if final_end:
                 if applied_ref_days:


### PR DESCRIPTION
## Summary
- fix sending Tribute success messages
- avoid None `final_end` for Telegram Stars payments

## Testing
- `python -m py_compile bot/handlers/user/subscription.py bot/handlers/webhooks/tribute.py`

------
https://chatgpt.com/codex/tasks/task_e_6859bf926a2c8321a487647e2192c275