### PR TITLE
Improve panel user handling and promo code activation

### DIFF
--- a/bot/services/promo_code_service.py
+++ b/bot/services/promo_code_service.py
@@ -5,7 +5,7 @@ from aiogram import Bot
 
 from config.settings import Settings
 
-from db.dal import promo_code_dal, user_dal, subscription_dal
+from db.dal import promo_code_dal, user_dal
 from db.models import PromoCode, User
 
 from .subscription_service import SubscriptionService
@@ -39,11 +39,6 @@ class PromoCodeService:
         if existing_activation:
             return False, _("promo_code_already_used_by_user",
                             code=code_input_upper)
-
-        active_sub = await subscription_dal.get_active_subscription_by_user_id(
-            session, user_id)
-        if not active_sub:
-            return False, _("promo_code_no_active_subscription")
 
         bonus_days = promo_data.bonus_days
 

--- a/db/dal/subscription_dal.py
+++ b/db/dal/subscription_dal.py
@@ -129,6 +129,21 @@ async def deactivate_other_active_subscriptions(
         )
 
 
+async def deactivate_all_user_subscriptions(
+        session: AsyncSession, user_id: int) -> int:
+    stmt = (
+        update(Subscription)
+        .where(Subscription.user_id == user_id, Subscription.is_active == True)
+        .values(is_active=False, status_from_panel="INACTIVE_USER_NOT_FOUND")
+    )
+    result = await session.execute(stmt)
+    if result.rowcount > 0:
+        logging.info(
+            f"Deactivated {result.rowcount} subscriptions for user {user_id} due to missing panel user."
+        )
+    return result.rowcount
+
+
 async def update_subscription_end_date(
         session: AsyncSession, subscription_id: int,
         new_end_date: datetime) -> Optional[Subscription]:


### PR DESCRIPTION
## Summary
- add helper to deactivate subscriptions when panel user missing
- auto-create panel user or subscription when extending time
- clear local data if panel user missing
- allow promo code activation without an existing subscription

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c75dbb8f08321bf9ed2b0a92e8446