### PR TITLE
Fix default inbounds not applied on user creation

### DIFF
--- a/bot/services/subscription_service.py
+++ b/bot/services/subscription_service.py
@@ -108,6 +108,7 @@ class SubscriptionService:
                 creation_response = await self.panel_service.create_panel_user(
                     username_on_panel=panel_username_on_panel_standard,
                     telegram_id=user_id,
+                    specific_inbound_uuids=self.settings.parsed_default_panel_user_inbound_uuids,
                 )
                 if (
                     creation_response


### PR DESCRIPTION
## Summary
- use parsed default inbound UUIDs when creating a new panel user

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685e7fd3f0048321b4f439ea444ca5fe