### PR TITLE
Fix panel user sync and clarify traffic settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,13 +78,13 @@ REFEREE_BONUS_DAYS_12_MONTHS=15
 PANEL_API_URL=http://your_panel_api_url/api
 PANEL_API_KEY=your_panel_api_key
 
-# Default settings for NEW panel users
-PANEL_USER_DEFAULT_EXPIRE_DAYS=1
-PANEL_USER_DEFAULT_TRAFFIC_BYTES=0
-PANEL_USER_DEFAULT_TRAFFIC_STRATEGY="NO_RESET"
+# User traffic limits (applied for all users)
+# 0 means unlimited
+USER_TRAFFIC_LIMIT_GB=0
+USER_TRAFFIC_STRATEGY="NO_RESET"
 
-# Default Inbounds for Panel Users (Optional, comma-separated UUIDs)
-PANEL_USER_DEFAULT_INBOUND_UUIDS=uuid1,uuid2,uuid3
+# Default Inbounds for Users (Optional, comma-separated UUIDs)
+USER_INBOUND_UUIDS=uuid1,uuid2,uuid3
 
 # Trial Settings
 TRIAL_ENABLED=True

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ This Telegram bot is designed to automate the sale and management of subscriptio
     * **Panel API Settings:**
         * `PANEL_API_URL`: Full URL to your Remnawave panel's API (e.g., `http://remnawave:3000/api` or `https://panel.yourdomain.com/api`).
         * `PANEL_API_KEY`: API Key for authenticating with the Remnawave panel.
-    * `PANEL_USER_DEFAULT_INBOUND_UUIDS`: (Optional) Comma-separated list of inbound UUIDs from your panel to assign to users. If empty, `activateAllInbounds: true` (panel default) is used for new users.
+    * `USER_INBOUND_UUIDS`: (Optional) Comma-separated list of inbound UUIDs from your panel to assign to users. If empty, `activateAllInbounds: true` (panel default) is used for new users.
+    * `USER_TRAFFIC_LIMIT_GB` and `USER_TRAFFIC_STRATEGY`: Default traffic limit in gigabytes (0 for unlimited) and the reset strategy applied when updating users on the panel.
     * `TRIAL_ENABLED`, `TRIAL_DURATION_DAYS`, `TRIAL_TRAFFIC_LIMIT_GB`: Settings for the trial period.
     * `WEB_SERVER_HOST`, `WEB_SERVER_PORT`: Host and port for the bot's internal webhook server.
     * `LOGS_PAGE_SIZE`: For admin panel log pagination.

--- a/bot/services/referral_service.py
+++ b/bot/services/referral_service.py
@@ -137,8 +137,7 @@ class ReferralService:
                                     "status_from_panel":
                                     "ACTIVE_BONUS",
                                     "traffic_limit_bytes":
-                                    self.settings.
-                                    PANEL_USER_DEFAULT_TRAFFIC_BYTES,
+                                    self.settings.user_traffic_limit_bytes,
                                 }
                                 try:
                                     await subscription_dal.deactivate_other_active_subscriptions(

--- a/config/settings.py
+++ b/config/settings.py
@@ -86,10 +86,9 @@ class Settings(BaseSettings):
 
     PANEL_API_URL: Optional[str] = None
     PANEL_API_KEY: Optional[str] = None
-    PANEL_USER_DEFAULT_EXPIRE_DAYS: int = Field(default=1)
-    PANEL_USER_DEFAULT_TRAFFIC_BYTES: int = Field(default=0)
-    PANEL_USER_DEFAULT_TRAFFIC_STRATEGY: str = Field(default="NO_RESET")
-    PANEL_USER_DEFAULT_INBOUND_UUIDS: Optional[str] = Field(
+    USER_TRAFFIC_LIMIT_GB: Optional[float] = Field(default=0.0)
+    USER_TRAFFIC_STRATEGY: str = Field(default="NO_RESET")
+    USER_INBOUND_UUIDS: Optional[str] = Field(
         default=None,
         description=
         "Comma-separated UUIDs of inbounds to activate for new panel users")
@@ -139,11 +138,18 @@ class Settings(BaseSettings):
 
     @computed_field
     @property
-    def parsed_default_panel_user_inbound_uuids(self) -> Optional[List[str]]:
-        if self.PANEL_USER_DEFAULT_INBOUND_UUIDS:
+    def user_traffic_limit_bytes(self) -> int:
+        if self.USER_TRAFFIC_LIMIT_GB is None or self.USER_TRAFFIC_LIMIT_GB <= 0:
+            return 0
+        return int(self.USER_TRAFFIC_LIMIT_GB * (1024**3))
+
+    @computed_field
+    @property
+    def parsed_user_inbound_uuids(self) -> Optional[List[str]]:
+        if self.USER_INBOUND_UUIDS:
             return [
                 uuid.strip()
-                for uuid in self.PANEL_USER_DEFAULT_INBOUND_UUIDS.split(',')
+                for uuid in self.USER_INBOUND_UUIDS.split(',')
                 if uuid.strip()
             ]
         return None


### PR DESCRIPTION
## Summary
- rename traffic env vars to USER_TRAFFIC_LIMIT_GB, USER_TRAFFIC_STRATEGY and USER_INBOUND_UUIDS
- update services and settings to use new names
- document updated variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68605fe891708321b7ea18765c328ae3