### PR TITLE
Support subscription mini app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ DEFAULT_CURRENCY_SYMBOL="RUB"  # e.g., RUB, USD, EUR
 SUPPORT_LINK=https://t.me/your_support_link
 SERVER_STATUS_URL=https://status.yourdomain.tld/status/your_service
 TERMS_OF_SERVICE_URL=https://example.com/tos
+SUBSCRIPTION_MINI_APP_URL=
 
 # YooKassa Payment Gateway Configuration
 YOOKASSA_SHOP_ID=your_shop_id

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ This Telegram bot is designed to automate the sale and management of subscriptio
     * `DEFAULT_CURRENCY_SYMBOL`: e.g., `RUB`, `USD`.
     * `SUPPORT_LINK`: (Optional) URL for a support chat/contact (e.g., `https://t.me/your_support`).
     * `SERVER_STATUS_URL`: (Optional) URL to a server status page (e.g., Uptime Kuma).
+    * `SUBSCRIPTION_MINI_APP_URL`: (Optional) URL of a Telegram mini app showing subscription details. If set, the bot will register this mini app via API so it can be launched from the bot menu.
     * **YooKassa Settings:**
         * `YOOKASSA_SHOP_ID`: Your shop ID from YooKassa.
         * `YOOKASSA_SECRET_KEY`: Your secret key from YooKassa.

--- a/bot/main_bot.py
+++ b/bot/main_bot.py
@@ -3,7 +3,7 @@ import asyncio
 from typing import Callable, Dict, Any, Awaitable, Optional
 
 from aiogram import Bot, Dispatcher, BaseMiddleware, Router, F
-from aiogram.types import Update
+from aiogram.types import Update, MenuButtonWebApp, WebAppInfo
 from aiogram.enums import ParseMode
 from aiogram.filters import CommandStart, Command
 from aiogram.client.default import DefaultBotProperties
@@ -170,6 +170,14 @@ async def on_startup_configured(dispatcher: Dispatcher):
             "STARTUP: TELEGRAM_WEBHOOK_BASE_URL not set in environment. Attempting to delete any existing webhook (running in polling mode)."
         )
         await bot.delete_webhook(drop_pending_updates=True)
+
+    if settings.SUBSCRIPTION_MINI_APP_URL:
+        menu_text = i18n_instance.gettext(settings.DEFAULT_LANGUAGE, "menu_my_subscription_inline")
+        try:
+            await bot.set_chat_menu_button(menu_button=MenuButtonWebApp(text=menu_text, web_app=WebAppInfo(url=settings.SUBSCRIPTION_MINI_APP_URL)))
+            logging.info("STARTUP: Menu button for subscription mini app set via API.")
+        except Exception as e:
+            logging.error(f"STARTUP: Failed to set menu button web app: {e}", exc_info=True)
 
     logging.info("STARTUP: Bot on_startup_configured completed.")
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -101,6 +101,8 @@ class Settings(BaseSettings):
     WEB_SERVER_PORT: int = Field(default=8080)
     LOGS_PAGE_SIZE: int = Field(default=10)
 
+    SUBSCRIPTION_MINI_APP_URL: Optional[str] = Field(default=None)
+
     @computed_field
     @property
     def DATABASE_URL(self) -> str:


### PR DESCRIPTION
## Summary
- add `SUBSCRIPTION_MINI_APP_URL` setting for enabling subscription mini app
- register mini app through the Telegram API at startup
- keep the existing "My Subscription" callback button
- document new setting

## Testing
- `python -m py_compile main.py bot/main_bot.py bot/keyboards/inline/user_keyboards.py config/settings.py`


------
https://chatgpt.com/codex/tasks/task_e_6867d9ddbe688321ba32237d5b13efa5