### PR TITLE
Fix HTML name escaping

### DIFF
--- a/bot/handlers/user/start.py
+++ b/bot/handlers/user/start.py
@@ -1,5 +1,6 @@
 import logging
 from aiogram import Router, F, types, Bot
+from aiogram.utils.text_decorations import html_decoration as hd
 from aiogram.filters import CommandStart, Command
 from aiogram.fsm.context import FSMContext
 from typing import Optional, Union
@@ -30,7 +31,7 @@ async def send_main_menu(target_event: Union[types.Message,
     i18n: Optional[JsonI18n] = i18n_data.get("i18n_instance")
 
     user_id = target_event.from_user.id
-    user_full_name = target_event.from_user.full_name
+    user_full_name = hd.quote(target_event.from_user.full_name)
 
     if not i18n:
         logging.error(
@@ -192,7 +193,7 @@ async def start_command_handler(message: types.Message,
                     f"Failed to update existing user {user_id} in session: {e_update}",
                     exc_info=True)
 
-    await message.answer(_(key="welcome", user_name=user.full_name))
+    await message.answer(_(key="welcome", user_name=hd.quote(user.full_name)))
     await send_main_menu(message,
                          settings,
                          i18n_data,

--- a/bot/services/notification_service.py
+++ b/bot/services/notification_service.py
@@ -1,6 +1,7 @@
 import logging
 import asyncio
 from aiogram import Bot
+from aiogram.utils.text_decorations import html_decoration as hd
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from datetime import datetime, timezone
 
@@ -48,7 +49,7 @@ async def send_expiration_warnings(bot: Bot, settings: Settings,
                 user_id = sub_details['user_id']
                 user_lang = sub_details.get('language_code',
                                             settings.DEFAULT_LANGUAGE)
-                first_name = sub_details.get('first_name', f"User {user_id}")
+                first_name = hd.quote(sub_details.get('first_name', f"User {user_id}"))
                 end_date_str_for_msg = sub_details.get('end_date_str', "N/A")
                 days_left_display = sub_details.get('days_left', "N/A")
 


### PR DESCRIPTION
## Summary
- sanitize user-provided names before inserting them into HTML messages
- escape first names in subscription notification service

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686e1a4b6f048321b4d93858483e1ac6