### PR TITLE
Add promo activation and tribute/star payment notifications

### DIFF
--- a/bot/services/notification_service.py
+++ b/bot/services/notification_service.py
@@ -177,3 +177,18 @@ async def notify_admin_new_payment(bot: Bot, settings: Settings, i18n: JsonI18n,
         amount=f"{amount:.2f}",
         currency=currency_symbol,
     )
+
+
+async def notify_admin_promo_activation(bot: Bot, settings: Settings,
+                                        i18n: JsonI18n, user_id: int,
+                                        code: str,
+                                        bonus_days: int) -> None:
+    await notify_admins(
+        bot,
+        settings,
+        i18n,
+        "admin_promo_activation_notification",
+        user_id=user_id,
+        code=code,
+        bonus_days=bonus_days,
+    )

--- a/bot/services/promo_code_service.py
+++ b/bot/services/promo_code_service.py
@@ -10,6 +10,7 @@ from db.models import PromoCode, User
 
 from .subscription_service import SubscriptionService
 from bot.middlewares.i18n import JsonI18n
+from .notification_service import notify_admin_promo_activation
 
 
 class PromoCodeService:
@@ -56,7 +57,14 @@ class PromoCodeService:
                 session, promo_data.promo_code_id)
 
             if activation_recorded and promo_incremented:
-
+                await notify_admin_promo_activation(
+                    self.bot,
+                    self.settings,
+                    self.i18n,
+                    user_id,
+                    code_input_upper,
+                    bonus_days,
+                )
                 return True, _("promo_code_applied_success",
                                code=code_input_upper,
                                bonus_days=bonus_days,

--- a/bot/services/stars_service.py
+++ b/bot/services/stars_service.py
@@ -10,6 +10,7 @@ from db.dal import payment_dal, user_dal
 from .subscription_service import SubscriptionService
 from .referral_service import ReferralService
 from bot.middlewares.i18n import JsonI18n
+from .notification_service import notify_admin_new_payment
 
 
 class StarsService:
@@ -132,4 +133,14 @@ class StarsService:
         except Exception as e_send:
             logging.error(
                 f"Failed to send stars payment success message: {e_send}")
+
+        await notify_admin_new_payment(
+            self.bot,
+            self.settings,
+            self.i18n,
+            message.from_user.id,
+            months,
+            float(stars_amount),
+            currency="XTR",
+        )
 

--- a/bot/services/tribute_service.py
+++ b/bot/services/tribute_service.py
@@ -13,6 +13,7 @@ from bot.middlewares.i18n import JsonI18n
 from bot.services.subscription_service import SubscriptionService
 from bot.services.panel_api_service import PanelApiService
 from bot.services.referral_service import ReferralService
+from .notification_service import notify_admin_new_payment
 from db.dal import payment_dal, user_dal, subscription_dal
 
 
@@ -157,6 +158,16 @@ class TributeService:
                     except Exception as e:
                         logging.error(
                             f"Failed to send Tribute payment success message to user {user_id}: {e}")
+
+                await notify_admin_new_payment(
+                    bot,
+                    settings,
+                    i18n,
+                    user_id,
+                    months,
+                    float(price_rub),
+                    currency="RUB",
+                )
             elif event_name == 'cancelled_subscription':
                 db_user = await user_dal.get_user_by_id(session, user_id)
                 lang = db_user.language_code if db_user and db_user.language_code else settings.DEFAULT_LANGUAGE

--- a/locales/en.json
+++ b/locales/en.json
@@ -216,6 +216,7 @@
 
   "admin_new_trial_notification": "\ud83c\udf21 User {user_id} activated a free trial until {end_date}.",
   "admin_new_payment_notification": "\ud83d\udcb3 Payment received from user {user_id}: {months} mo. for {amount} {currency}.",
+  "admin_promo_activation_notification": "\ud83c\udf81 Promo code {code} activated by user {user_id} (+{bonus_days}d).",
 
   "error_unknown": "An unknown error occurred."
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -216,6 +216,7 @@
 
   "admin_new_trial_notification": "\ud83c\udf21 Пользователь {user_id} активировал пробный период до {end_date}.",
   "admin_new_payment_notification": "\ud83d\udcb3 Получен платеж от пользователя {user_id}: {months} мес. за {amount} {currency}.",
+  "admin_promo_activation_notification": "\ud83c\udf81 Пользователь {user_id} активировал промокод {code} (+{bonus_days} дн.)",
 
   "error_unknown": "Произошла неизвестная ошибка."
 }


### PR DESCRIPTION
## Summary
- notify admins when users activate promo codes
- send admin notifications for payments done via Telegram stars and Tribute
- translate new admin message for English and Russian locales

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687100d8dfa48321a788698cb66d25d3