### PR TITLE
Fix webhook user extraction and notification logic

### DIFF
--- a/bot/services/panel_webhook_service.py
+++ b/bot/services/panel_webhook_service.py
@@ -47,7 +47,7 @@ class PanelWebhookService:
 
         if event_name in EVENT_MAP:
             days_left, msg_key = EVENT_MAP[event_name]
-            if days_left == self.settings.SUBSCRIPTION_NOTIFY_DAYS_BEFORE:
+            if days_left <= self.settings.SUBSCRIPTION_NOTIFY_DAYS_BEFORE:
                 await self._send_message(
                     user_id,
                     lang,
@@ -78,7 +78,9 @@ class PanelWebhookService:
             return web.Response(status=400, text="bad_request")
 
         event_name = payload.get("name") or payload.get("event")
-        user_data = payload.get("payload", {}).get("user") or payload.get("payload", {})
+        user_data = payload.get("payload") or payload.get("data", {})
+        if isinstance(user_data, dict) and "user" in user_data:
+            user_data = user_data.get("user") or user_data
         if not event_name:
             return web.Response(status=200, text="ok_no_event")
 


### PR DESCRIPTION
## Summary
- ensure subscription notifications fire on days prior to expiry
- robustly select user data from webhook payload

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687143b191c48321987e84ac24be18c6