### PR TITLE
Support fiat invoices in Crypto Pay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,8 @@ YOOKASSA_PAYMENT_SUBJECT=payment
 # CryptoBot Payment Gateway Configuration
 CRYPTOPAY_TOKEN=
 CRYPTOPAY_NETWORK=mainnet
-CRYPTOPAY_ASSET=TON
+CRYPTOPAY_CURRENCY_TYPE=fiat
+CRYPTOPAY_ASSET=RUB
 # API key for verifying Tribute webhook signatures
 TRIBUTE_API_KEY=
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This Telegram bot is designed to automate the sale and management of subscriptio
 * **Subscription Management:**
     * Handles subscription purchases for various periods (1, 3, 6, 12 months).
     * Integrates with **YooKassa** for payment processing, including fiscal receipt data.
-    * Supports **Crypto Pay** for cryptocurrency payments.
+    * Supports **Crypto Pay** for payments with fiat currency (RUB by default).
     * Automatic subscription activation/extension upon successful payment.
     * Link and syncs users with a **Remnawave panel** account, primarily matching by Telegram ID.
     * Updates user status, expiration dates, traffic limits, and inbounds on the Remnawave panel.
@@ -95,7 +95,7 @@ This Telegram bot is designed to automate the sale and management of subscriptio
         * `YOOKASSA_VAT_CODE`: VAT code for items in receipt (e.g., `1` for "No VAT". Consult YooKassa documentation and tax advisor).
         * `YOOKASSA_PAYMENT_MODE`: e.g., `full_prepayment`.
         * `YOOKASSA_PAYMENT_SUBJECT`: e.g., `service`.
-    * **Crypto Pay Settings:** `CRYPTOPAY_TOKEN`, `CRYPTOPAY_NETWORK` (`mainnet` or `testnet`), `CRYPTOPAY_ASSET` (e.g., `TON`). Enable with `CRYPTOPAY_ENABLED`.
+* **Crypto Pay Settings:** `CRYPTOPAY_TOKEN`, `CRYPTOPAY_NETWORK` (`mainnet` or `testnet`), `CRYPTOPAY_CURRENCY_TYPE` (`fiat` or `crypto`), `CRYPTOPAY_ASSET` (e.g., `RUB`). Enable with `CRYPTOPAY_ENABLED`.
     * **Payment Method Toggles:** `YOOKASSA_ENABLED`, `STARS_ENABLED`, `TRIBUTE_ENABLED`, `CRYPTOPAY_ENABLED`.
     * **Subscription Options:** For each duration you can use variables like
       `1_MONTH_ENABLED`, `RUB_PRICE_1_MONTH`, `STARS_PRICE_1_MONTH`, `TRIBUTE_LINK_1_MONTH`

--- a/bot/services/crypto_pay_service.py
+++ b/bot/services/crypto_pay_service.py
@@ -78,7 +78,9 @@ class CryptoPayService:
         try:
             invoice = await self.client.create_invoice(
                 amount=amount,
-                asset=self.settings.CRYPTOPAY_ASSET,
+                currency_type=self.settings.CRYPTOPAY_CURRENCY_TYPE,
+                fiat=self.settings.CRYPTOPAY_ASSET if self.settings.CRYPTOPAY_CURRENCY_TYPE == "fiat" else None,
+                asset=self.settings.CRYPTOPAY_ASSET if self.settings.CRYPTOPAY_CURRENCY_TYPE == "crypto" else None,
                 description=description,
                 payload=payload,
             )

--- a/config/settings.py
+++ b/config/settings.py
@@ -37,7 +37,8 @@ class Settings(BaseSettings):
 
     CRYPTOPAY_TOKEN: Optional[str] = None
     CRYPTOPAY_NETWORK: str = Field(default="mainnet")
-    CRYPTOPAY_ASSET: str = Field(default="TON")
+    CRYPTOPAY_CURRENCY_TYPE: str = Field(default="fiat")
+    CRYPTOPAY_ASSET: str = Field(default="RUB")
     CRYPTOPAY_ENABLED: bool = Field(default=True)
 
     YOOKASSA_ENABLED: bool = Field(default=True)


### PR DESCRIPTION
## Summary
- add `CRYPTOPAY_CURRENCY_TYPE` setting with default `fiat`
- use `currency_type` and `fiat` when creating Crypto Pay invoices
- document the new setting in README and `.env.example`
- clarify in README that Crypto Pay uses fiat payments by default

## Testing
- `python -m py_compile config/settings.py bot/services/crypto_pay_service.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_688357a093408321a263c9dafef0e5b9