### PR TITLE
Close services and update event loop usage

### DIFF
--- a/bot/services/crypto_pay_service.py
+++ b/bot/services/crypto_pay_service.py
@@ -46,6 +46,15 @@ class CryptoPayService:
             self.client = None
             self.configured = False
 
+    async def close(self):
+        """Close underlying AioCryptoPay session if initialized."""
+        if self.client:
+            try:
+                await self.client.close()
+                logging.info("CryptoPay client session closed.")
+            except Exception as e:
+                logging.warning(f"Failed to close CryptoPay client: {e}")
+
     async def create_invoice(
         self,
         session: AsyncSession,

--- a/bot/services/panel_api_service.py
+++ b/bot/services/panel_api_service.py
@@ -34,6 +34,10 @@ class PanelApiService:
             self._session = None
             logging.info("Panel API service HTTP session closed.")
 
+    async def close(self):
+        """Alias for close_session for API consistency."""
+        await self.close_session()
+
     async def _prepare_headers(self) -> Dict[str, str]:
         headers = {
             "Content-Type": "application/json",

--- a/bot/services/yookassa_service.py
+++ b/bot/services/yookassa_service.py
@@ -142,7 +142,7 @@ class YooKassaService:
                 f"Amount: {amount} {currency}. Metadata: {metadata}. Receipt: {receipt_data_dict}"
             )
 
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             response = await loop.run_in_executor(
                 None, lambda: YooKassaPayment.create(payment_request,
                                                      idempotence_key))
@@ -196,7 +196,7 @@ class YooKassaService:
                 f"Fetching payment info from YooKassa for ID: {payment_id_in_yookassa}"
             )
 
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             payment_info_yk = await loop.run_in_executor(
                 None, lambda: YooKassaPayment.find_one(payment_id_in_yookassa))
 


### PR DESCRIPTION
## Summary
- ensure the dispatcher provides itself to the shutdown handler
- close CryptoPayService and PanelApiService sessions on shutdown
- use `asyncio.get_running_loop` in `YooKassaService`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6888a9a3413c8321b2937e04b33b6dae