### PR TITLE
Update API service for squads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,8 +92,8 @@ PANEL_WEBHOOK_SECRET=   # secret used to verify panel webhook signatures
 USER_TRAFFIC_LIMIT_GB=0
 USER_TRAFFIC_STRATEGY="NO_RESET"
 
-# Default Inbounds for Users (Optional, comma-separated UUIDs)
-USER_INBOUND_UUIDS=uuid1,uuid2,uuid3
+# Default Internal Squads for Users (Optional, comma-separated UUIDs)
+USER_SQUAD_UUIDS=uuid1,uuid2,uuid3
 
 # Trial Settings
 TRIAL_ENABLED=True

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This Telegram bot is designed to automate the sale and management of subscriptio
     * Supports **Crypto Pay** for payments with fiat currency (RUB by default).
     * Automatic subscription activation/extension upon successful payment.
     * Link and syncs users with a **Remnawave panel** account, primarily matching by Telegram ID.
-    * Updates user status, expiration dates, traffic limits, and inbounds on the Remnawave panel.
+    * Updates user status, expiration dates, traffic limits, and internal squads on the Remnawave panel.
 * **Admin Panel:**
     * Protected by `ADMIN_IDS` (supports multiple administrators).
     * **Statistics:** View bot usage (total users, banned, active subscriptions), recent payments, and panel sync status.
@@ -104,7 +104,7 @@ This Telegram bot is designed to automate the sale and management of subscriptio
         * `PANEL_API_URL`: Full URL to your Remnawave panel's API (e.g., `http://remnawave:3000/api` or `https://panel.yourdomain.com/api`).
         * `PANEL_API_KEY`: API Key for authenticating with the Remnawave panel.
         * `PANEL_WEBHOOK_SECRET`: Secret key for verifying webhooks from the Remnawave panel.
-    * `USER_INBOUND_UUIDS`: (Optional) Comma-separated list of inbound UUIDs from your panel to assign to users. If empty, `activateAllInbounds: true` (panel default) is used for new users.
+    * `USER_SQUAD_UUIDS`: (Optional) Comma-separated list of internal squad UUIDs from your panel to assign to users during creation.
     * `USER_TRAFFIC_LIMIT_GB` and `USER_TRAFFIC_STRATEGY`: Default traffic limit in gigabytes (0 for unlimited) and the reset strategy applied when updating users on the panel.
     * `TRIAL_ENABLED`, `TRIAL_DURATION_DAYS`, `TRIAL_TRAFFIC_LIMIT_GB`: Settings for the trial period.
     * `WEB_SERVER_HOST`, `WEB_SERVER_PORT`: Host and port for the bot's internal webhook server.

--- a/bot/services/panel_api_service.py
+++ b/bot/services/panel_api_service.py
@@ -329,8 +329,7 @@ class PanelApiService:
             default_expire_days: int = 1,
             default_traffic_limit_bytes: int = 0,
             default_traffic_limit_strategy: str = "NO_RESET",
-            specific_inbound_uuids: Optional[List[str]] = None,
-            activate_all_inbounds_default_flag: bool = True,
+            specific_squad_uuids: Optional[List[str]] = None,
             description: Optional[str] = None,
             tag: Optional[str] = None,
             status: str = "ACTIVE",
@@ -361,11 +360,8 @@ class PanelApiService:
             "trafficLimitStrategy": default_traffic_limit_strategy.upper(),
             "trafficLimitBytes": default_traffic_limit_bytes,
         }
-        if specific_inbound_uuids:
-            payload["activeUserInbounds"] = specific_inbound_uuids
-            payload["activateAllInbounds"] = False
-        else:
-            payload["activateAllInbounds"] = activate_all_inbounds_default_flag
+        if specific_squad_uuids:
+            payload["activeInternalSquads"] = specific_squad_uuids
         if telegram_id is not None: payload["telegramId"] = telegram_id
         if email: payload["email"] = email
         if description: payload["description"] = description

--- a/bot/services/subscription_service.py
+++ b/bot/services/subscription_service.py
@@ -105,7 +105,7 @@ class SubscriptionService:
                     creation_response = await self.panel_service.create_panel_user(
                         username_on_panel=panel_username_on_panel_standard,
                         telegram_id=user_id,
-                        specific_inbound_uuids=self.settings.parsed_user_inbound_uuids,
+                        specific_squad_uuids=self.settings.parsed_user_squad_uuids,
                         default_traffic_limit_bytes=self.settings.user_traffic_limit_bytes,
                         default_traffic_limit_strategy=self.settings.USER_TRAFFIC_STRATEGY,
                     )
@@ -128,7 +128,7 @@ class SubscriptionService:
                 creation_response = await self.panel_service.create_panel_user(
                     username_on_panel=panel_username_on_panel_standard,
                     telegram_id=user_id,
-                    specific_inbound_uuids=self.settings.parsed_user_inbound_uuids,
+                    specific_squad_uuids=self.settings.parsed_user_squad_uuids,
                     default_traffic_limit_bytes=self.settings.user_traffic_limit_bytes,
                     default_traffic_limit_strategy=self.settings.USER_TRAFFIC_STRATEGY,
                 )
@@ -357,12 +357,10 @@ class SubscriptionService:
             "trafficLimitBytes": self.settings.trial_traffic_limit_bytes,
             "trafficLimitStrategy": self.settings.USER_TRAFFIC_STRATEGY,
         }
-        if self.settings.parsed_user_inbound_uuids:
-            panel_update_payload["activeUserInbounds"] = (
-                self.settings.parsed_user_inbound_uuids
+        if self.settings.parsed_user_squad_uuids:
+            panel_update_payload["activeInternalSquads"] = (
+                self.settings.parsed_user_squad_uuids
             )
-        elif panel_user_created_now:
-            panel_update_payload["activateAllInbounds"] = True
 
         updated_panel_user = await self.panel_service.update_user_details_on_panel(
             panel_user_uuid, panel_update_payload
@@ -506,12 +504,10 @@ class SubscriptionService:
             "trafficLimitBytes": self.settings.user_traffic_limit_bytes,
             "trafficLimitStrategy": self.settings.USER_TRAFFIC_STRATEGY,
         }
-        if self.settings.parsed_user_inbound_uuids:
-            panel_update_payload["activeUserInbounds"] = (
-                self.settings.parsed_user_inbound_uuids
+        if self.settings.parsed_user_squad_uuids:
+            panel_update_payload["activeInternalSquads"] = (
+                self.settings.parsed_user_squad_uuids
             )
-        elif panel_user_created_now:
-            panel_update_payload["activateAllInbounds"] = True
 
         updated_panel_user = await self.panel_service.update_user_details_on_panel(
             panel_user_uuid, panel_update_payload

--- a/config/settings.py
+++ b/config/settings.py
@@ -95,10 +95,10 @@ class Settings(BaseSettings):
     PANEL_API_KEY: Optional[str] = None
     USER_TRAFFIC_LIMIT_GB: Optional[float] = Field(default=0.0)
     USER_TRAFFIC_STRATEGY: str = Field(default="NO_RESET")
-    USER_INBOUND_UUIDS: Optional[str] = Field(
+    USER_SQUAD_UUIDS: Optional[str] = Field(
         default=None,
         description=
-        "Comma-separated UUIDs of inbounds to activate for new panel users")
+        "Comma-separated UUIDs of internal squads to assign to new panel users")
 
     TRIAL_ENABLED: bool = Field(default=True)
     TRIAL_DURATION_DAYS: int = Field(default=3)
@@ -156,11 +156,11 @@ class Settings(BaseSettings):
 
     @computed_field
     @property
-    def parsed_user_inbound_uuids(self) -> Optional[List[str]]:
-        if self.USER_INBOUND_UUIDS:
+    def parsed_user_squad_uuids(self) -> Optional[List[str]]:
+        if self.USER_SQUAD_UUIDS:
             return [
                 uuid.strip()
-                for uuid in self.USER_INBOUND_UUIDS.split(',')
+                for uuid in self.USER_SQUAD_UUIDS.split(',')
                 if uuid.strip()
             ]
         return None


### PR DESCRIPTION
## Summary
- support new Remnawave API changes
- handle internal squads in panel API service and subscription flow
- rename USER_INBOUND_UUIDS env variable to USER_SQUAD_UUIDS

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b8f15ef48321988020accf2dc27e